### PR TITLE
Add support for Data Profile tables

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,8 @@ Description: Provides a general toolkit for downloading, managing,
   complex acs objects.  Package provides new methods to conduct
   standard operations on acs objects and present/plot data in
   statistically appropriate ways. Current version is 2.0 +/- .033.
-Suggests:
+Suggests: R.cache,
+    testthat
 Imports: graphics, stats, utils, RCurl
 Depends: R (>= 2.10), stringr, methods, plyr, XML
 License: GPL-3

--- a/R/acs.R
+++ b/R/acs.R
@@ -123,6 +123,11 @@ api.url.maker=function(endyear, span, key, variables, dataset, geo.call) {
   api.url
 }
 
+# a function to determine if the api key has been set.
+api.key.exists=function() {
+     return(file.exists(file.path(system.file(package="acs"), "extdata", "key.rda")))
+}
+
 # a function to install a users key for use in this and future
 # sessions
 # writes to package extdata directory

--- a/R/acs.R
+++ b/R/acs.R
@@ -115,7 +115,11 @@ api.url.maker=function(endyear, span, key, variables, dataset, geo.call) {
   api.for=paste0("for=",paste(names(api.for(geo.call)), api.for(geo.call), sep=":"))
   api.in=paste0(paste(names(api.in(geo.call)), api.in(geo.call), sep=":"), collapse="+")
   if (!identical(api.in, "")) api.in=paste0("&in=",api.in)
-  api.url=paste0("http://api.census.gov/data/", endyear, "/" , dataset, span, "?key=", key, "&get=", variables, ",NAME&", api.for, api.in)
+  if (dataset == "acs_dp" ) {
+	  api.url=paste0("http://api.census.gov/data/", endyear, "/acs" , span, "/profile?key=", key, "&get=", variables, ",NAME&", api.for, api.in)
+  } else {
+	  api.url=paste0("http://api.census.gov/data/", endyear, "/" , dataset, span, "?key=", key, "&get=", variables, ",NAME&", api.for, api.in)
+  }
   api.url
 }
 
@@ -124,8 +128,9 @@ api.url.maker=function(endyear, span, key, variables, dataset, geo.call) {
 # writes to package extdata directory
 
 api.key.install=function(key, file="key.rda") {
-    dir.create(paste(system.file(package="acs"), "extdata", sep="/"), showWarnings=F)
-    save(key, file=paste(system.file("extdata", package="acs"), file, sep="/"))
+    dirpath = file.path(system.file(package="acs"), "extdata")
+    dir.create(dirpath, showWarnings=F)
+    save(key, file=file.path(dirpath, file))
 }
 
 # a function to migrate a previously installed api.key after package update
@@ -134,8 +139,8 @@ api.key.install=function(key, file="key.rda") {
 api.key.migrate=function() {
   key.path=system.file("../key-holder.rda", package="acs")
   if(file.exists(key.path)) {
-      dir.create(paste(system.file(package="acs"), "extdata", sep="/"), showWarnings=F)
-      file.copy(from=key.path, to=paste(system.file("extdata", package="acs"), "key.rda", sep="/"), overwrite=T)
+      dir.create(file.path(system.file(package="acs"), "extdata"), showWarnings=F)
+      file.copy(from=key.path, to=file.path(system.file("extdata", package="acs"), "key.rda"), overwrite=T)
   } else {warning("No archived key found;\n  try api.key.install with new key.")}
 }
  
@@ -145,7 +150,7 @@ api.key.migrate=function() {
 
 acs.tables.install=function() {
     filelist=readLines("http://web.mit.edu/eglenn/www/acs/acs-variables/filelist.txt")
-    dir.create(paste(system.file(package="acs"), "extdata", sep="/"), showWarnings=F)
+    dir.create(file.path(system.file(package="acs"), "extdata"), showWarnings=F)
     for (i in filelist) {
         download.file(url=paste("http://web.mit.edu/eglenn/www/acs/acs-variables/", i, sep=""), destfile=paste(system.file("extdata/", package="acs"), i, sep=""))}
 }
@@ -826,7 +831,11 @@ setClass(Class="acs.lookup", representation =
       if (!missing(table.number)){
         if (!missing(table.name)) warning("Cannot specify both table.name and table.number; using table.number")
    # in future?: consider changing next line to table.name="", and let table.number drive the train
-        if(endyear!=1990){table.name=paste(table.number, ".", sep="")} else {table.name=table.number}
+        if(endyear!=1990){
+             if(dataset=="acs_dp") {suffix = "_"}
+             else {suffix = "."}
+             table.name=paste(table.number, suffix, sep="")
+        } else {table.name=table.number}
 }
       if (missing(table.name) && missing(keyword)) {
         warning("No search terms provided; returning NA")
@@ -846,7 +855,11 @@ setClass(Class="acs.lookup", representation =
         doc.string=paste(dataset,"_", span,"yr_", endyear,"_var.xml.gz", sep="")
         doc.url=paste("http://api.census.gov/data/", endyear,"/acs",span,"/variables.xml", sep="")
       }
-      if(dataset=="sf1" | dataset=="sf3"){
+      else if(dataset=="acs_dp") {
+        doc.string=paste(dataset,"_", span,"yr_", endyear,"_var.xml.gz", sep="")
+        doc.url=paste("http://api.census.gov/data/", endyear,"/acs",span,"/profile/variables.xml", sep="")
+      }
+      else if(dataset=="sf1" | dataset=="sf3"){
         doc.string=paste(dataset,"_", endyear,".xml.gz", sep="")
         doc.url=paste("http://api.census.gov/data/", endyear, "/", dataset, "/variables.xml", sep="")
         span=0
@@ -877,6 +890,8 @@ setClass(Class="acs.lookup", representation =
         return(NA)
       }
       
+      ###############
+      # Build an XML search string to query the variable lookup tables
       if (!missing(keyword)){
           if (!case.sensitive) {str.a="contains(translate(@label, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz'),'"}
         else {str.a="contains(@label, '"}
@@ -886,8 +901,10 @@ setClass(Class="acs.lookup", representation =
       } else {keyword=""}
 # add in stanza using table number
       if (!missing(table.name)) {
-          if (!case.sensitive) {str.a="contains(translate(@concept, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz'),'"}
-        else {str.a="contains(@concept, '"}
+          if(dataset=="acs_dp") {search_attr="@xml:id"}
+          else {search_attr="@concept"}
+          if (!case.sensitive) {str.a=paste("contains(translate(",search_attr,", 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz'),'",sep="")}
+          else {str.a=paste("contains(",search_attr,", '",sep="")}
           str.b=paste(str.a,table.name,"')", sep="")
           str.c=paste(str.b, collapse=" and ")
           table.name=str.c
@@ -903,54 +920,45 @@ setClass(Class="acs.lookup", representation =
       else {
              STRING=paste0("//ns:var[", paste(table.name, keyword, sep=" and "), "]")
       }
-# get variable codegs ("id")
-      names=suppressWarnings(xpathSApply(doc, STRING, namespaces="ns", xmlGetAttr, "xml:id"))
-      names=gsub("!!!!"," ",names)
-      names=gsub("!!"," ",names)
-      my.index=order(names)  # added for 2012, since data not sorted
-      names=names[my.index]  # added for 2012, since data not sorted
-      names=gsub("E$", "", names) # remove "E" from variable name
-      if(dataset=="acs" && length(names)>0) {names=names[seq(1,length(names),2)]} # only want every other
-    
-# get table names 
-      table.names=suppressWarnings(xpathSApply(doc, STRING, namespaces="ns", xmlGetAttr, "concept"))
-      table.names=gsub("!!!!"," ",table.names)
-      table.names=gsub("!!"," ",table.names)
-      table.numbers=regmatches(table.names, m=regexpr(table.names, pattern="^.*\\.")) # find table numbers
-      if(endyear==1990){
-        table.numbers=substr(names, 1, 5)
-        table.numbers=gsub(x=table.numbers, pattern="0$", replacement="")
-        table.numbers=gsub(x=table.numbers, pattern="$", replacement=".")
+      # Search the XML records and convert into a single dataframe (nodes as rows, attributes as columns). The columns id, label and concept will be relevant.
+      xml_dataframe = as.data.frame(t(suppressWarnings(xpathSApply(doc, STRING, namespaces="ns", xmlAttrs))))
+      # Replace !!!! and !! with spaces to ease parsing.
+      for (column in names(xml_dataframe)) { xml_dataframe[,column] = gsub("!!!!|!!", " ", xml_dataframe[,column]) }
+      # Filter out rows that are margins of error or percents (suffixes M, PE, & PM). 
+      remove_rows = grep(pattern="(PE|PM|M)$", xml_dataframe$id)
+      xml_dataframe = xml_dataframe[-1 * remove_rows,]
+      # Sort by id (legacy behavior)
+      xml_dataframe = xml_dataframe[order(xml_dataframe$id),]
+      # Extract root variable ids by deleting the E suffix from the id column in the remaining rows
+      xml_dataframe$census_var_code = gsub("E$", "", xml_dataframe$id)
+      # Clean up the human-readable name of the variable
+      xml_dataframe$var_name = gsub(x=xml_dataframe$label, pattern="*\\[.*\\]", replacement=":") # remove bracketed variable counts from SF1/SF3 tables 
+      # Extract table names (not ids)
+      xml_dataframe$table.names=gsub(x=xml_dataframe$concept, pattern="^.*\\.  ", replacement="") # remove table numbers from names 
+      xml_dataframe$table.names=gsub(x=xml_dataframe$table.names, pattern="* \\[.*\\]$", replacement="") # remove bracketed variable counts from SF1/SF3 tables 
+      # Extract table ids
+      if(dataset=="acs_dp") {
+           xml_dataframe$table.id = regmatches(xml_dataframe$id, m=regexpr(xml_dataframe$id, pattern = "^([^_]+)(?=_)", perl=TRUE))
+      } else {
+           if(endyear!=1990){
+                # Parse the table ids from the beginning of concept column, excluding the trailing dot '.'
+                xml_dataframe$table.id = regmatches(xml_dataframe$concept, m=regexpr(xml_dataframe$concept, pattern = "^[^\\.]+(?=\\. )", perl=TRUE))
+           } else { # Table ids were formatted differently in 1990 for sf1 & sf3..
+                xml_dataframe$table.id = substr(xml_dataframe$id, 1, 5)
+                xml_dataframe$table.id = gsub(x=xml_dataframe$table.id, pattern="0$", replacement="")
+           }
       }
-      table.names=gsub(x=table.names, pattern="^.*\\.  ", replacement="") # remove table numbers from names 
-      table.names=gsub(x=table.names, pattern="* \\[.*\\]$", replacement="") # remove bracketed variable counts from SF1/SF3 tables 
-      table.names=table.names[my.index] # added for 2012, since data not sorted
-      if(dataset=="acs" && length(table.names)>0) {table.names=table.names[seq(1,length(table.names),2)]} # only want every other
-      
-# get table numbers
-      table.numbers=substr(table.numbers, 1, unlist(lapply(table.numbers, nchar))-1) # remove trailing period
-      if(dataset=="acs"){  # sf1/sf3 table.numbers have already been reordered!
-        table.numbers=table.numbers[my.index]
-      } # added for 2012, since data not sorted
-      if(dataset=="acs" && length(table.numbers)>0) {table.numbers=table.numbers[seq(1,length(table.numbers),2)]} # only want every other
-    
-# get variable names
-      values=suppressWarnings(xpathSApply(doc, STRING, namespaces="ns", xmlGetAttr, "label"))
-      values=gsub("!!!!"," ",values)
-      values=gsub("!!"," ",values)
-      values=gsub(x=values, pattern="*\\[.*\\]", replacement=":") # remove bracketed variable counts from SF1/SF3 tables 
-      values=values[my.index] # added for 2012, since data not sorted
-      if(dataset=="acs"  && length(values)>0) {values=values[seq(1,length(values),2)]} # only want every other
-    
-      if (length(names)==0){
+
+      if (length(xml_dataframe)==0){
         warning("Sorry, no tables/keyword meets your search.\n  Suggestions:\n    try with 'case.sensitive=F',\n    remove search terms,\n    change 'keyword' to 'table.name' in search (or vice-versa)")
         return(NA)}
       free(doc)
       rm(doc)
       gc()
       new(Class="acs.lookup", endyear=endyear, span=span, args=arglist, 
-            results=data.frame(variable.code=names, 
-            table.number=table.numbers, table.name=table.names, variable.name=values, 
+            results=data.frame(variable.code=xml_dataframe$census_var_code, 
+            table.number=xml_dataframe$table.id, table.name=xml_dataframe$table.names,
+            variable.name=xml_dataframe$var_name, 
             stringsAsFactors=F))
     }
 
@@ -1125,7 +1133,7 @@ acs.fetch=function(endyear, span=5, geography, table.name,
           arglist=as.list(environment())
           missing.args=unlist(lapply(arglist, is.symbol))
           arglist=arglist[!missing.args]
-#          arglist$dataset="acs"
+          arglist$dataset=dataset
           arglist=arglist[names(arglist)!="variable"]
           arglist=arglist[names(arglist)!="geography"]
           arglist=arglist[names(arglist)!="key"]
@@ -1139,13 +1147,14 @@ acs.fetch=function(endyear, span=5, geography, table.name,
           variables.xml=results(variable)
           variables=variables.xml$variable.code
 # next "if" added to allow for sf1/sf3 fetching
-          if(dataset=="acs") {variables=paste(rep(variables, each=2), c("E","M"), sep="")}
+          # Expand the variable list from (v1, v2...) to (v1E, v1M, v2E, v2M...) to retrieve estimates & margins of error on alternating columns
+          if(dataset=="acs" || dataset=="acs_dp") {variables=paste(rep(variables, each=2), c("E","M"), sep="")}
         }
         if (!is.acs.lookup(variable)) {
           if (variable[1]=="recur") {
             variables=variable[2:length(variable)]}
           else {
-            if(dataset=="acs") {variables=paste(rep(variable, each=2), c("E","M"), sep="")}
+            if(dataset=="acs" || dataset=="acs_dp") {variables=paste(rep(variable, each=2), c("E","M"), sep="")}
             if(dataset=="sf1" | dataset=="sf3"){variables=variable}
             }
           if (variable[1]=="") {
@@ -1168,11 +1177,11 @@ acs.fetch=function(endyear, span=5, geography, table.name,
             col.names=paste(variables.xml$table.name, variables.xml$variable.name, sep=": ")
           }}
     #    if (identical(acs.units, "auto")) acs.units=rep("auto",(length(variables)/2))
-        if (identical(col.names, "auto") & dataset=="acs") col.names=rep("auto",(length(variables)/2))
+        if (identical(col.names, "auto") & (dataset=="acs" || dataset=="acs_dp")) col.names=rep("auto",(length(variables)/2))
         if (identical(col.names, "auto") & (dataset=="sf1" | dataset=="sf3")) col.names=rep("auto",length(variables))
         # deal with too many variables -- API currently limits to < 50
         # note two versions: acs datasets have doubled variables
-        if (length(variables) > var.max & dataset=="acs") {
+        if (length(variables) > var.max & (dataset=="acs" || dataset=="acs_dp")) {
           acs.obj=cbind(acs.fetch(endyear=endyear, span=span, geography=geography, variable=c("recur", variables[1:(var.max-2)]), key=key, dataset=dataset, col.names=col.names[1:((var.max-2)/2)]), acs.fetch(endyear=endyear, span=span, geography=geography, variable=c("recur", variables[(var.max-1):length(variables)]), col.names=col.names[(1+((var.max-2)/2)):length(col.names)], key=key, dataset=dataset))
           return(acs.obj)
         }
@@ -1216,7 +1225,7 @@ acs.fetch=function(endyear, span=5, geography, table.name,
         ## col.names=names(in.data)[seq(1,(length(in.data)-geo.length), 2)]
         ## col.names[1]=gsub("X..","",col.names[1])
         if (identical(col.names[1], "auto")) {  # check this!
-          if(dataset=="acs"){
+          if(dataset=="acs" || dataset=="acs_dp"){
           col.names=names(in.data)[seq(1,(length(in.data)-geo.length), 2)]
           } else if(dataset=="sf1" | dataset=="sf3") {
           col.names=names(in.data)[1:(length(in.data)-geo.length)]
@@ -1242,7 +1251,7 @@ acs.fetch=function(endyear, span=5, geography, table.name,
     #    acs.units=factor(acs.units, levels=.acs.unit.levels)
         GEOGRAPHY=as.data.frame(in.data[,geocols])
         names(GEOGRAPHY)=gsub(".", "", names(GEOGRAPHY), fixed=T) # remove strange trailing period
-        if(dataset=="acs"){
+        if(dataset=="acs" || dataset=="acs_dp"){
         acs.obj=new(Class="acs",
           endyear=endyear,
           span=span, 

--- a/man/acs.fetch.Rd
+++ b/man/acs.fetch.Rd
@@ -64,10 +64,10 @@ be 2011)}
       (Note: when set, this variable is passed to an internal call to
       acs.lookup---see \code{\link{acs.lookup}}).}
 
-  \item{dataset}{either "acs" (the default), "sf1", or "sf3", indicating
-    whether to fetch data from in the American Community Survey or the
-    SF1/SF3 datasets.  See details for more information about available
-    data.}
+  \item{dataset}{either "acs" (the default), "acs_dp", "sf1", or "sf3", indicating
+    whether to fetch data from in the American Community Survey, Data Profile tables
+    from the ACS, or the SF1/SF3 datasets.  See details for more information about 
+    available data.}
 
     \item{key}{a string providing the Census API key to use for when
       fetching data.  Typically saved once via \code{api.key.install}
@@ -154,6 +154,18 @@ fetched data from the Census API.  }
 Ezra Haber Glenn \email{eglenn@mit.edu}
 }
 
+\examples{
+acs.fetch(
+	endyear=2013, span = 5,
+	geography=geo.make(zip.code='94709'),
+	table.number="B01003",
+	dataset="acs")
+acs.fetch(
+	endyear=2013, span = 5,
+	geography=geo.make(zip.code='94709'),
+	table.number="DP02",
+	dataset="acs_dp")
+}
 
 \seealso{
 \code{\link{acs.lookup}}.

--- a/man/acs.lookup.Rd
+++ b/man/acs.lookup.Rd
@@ -43,10 +43,10 @@ acs.lookup(endyear, span = 5, dataset = "acs", keyword,
     ACS data (should be 1, 3, or 5); defaults to 5.  Ignored and reset
     to 0 if dataset="sf1" or "sf3".}
 
-  \item{dataset}{either "acs" (the default), "sf1", or "sf3", indicating
-    whether to look for tables and variables in the American Community
-    Survey, the SF1 dataset (decennial/"short-form"), or the SF3 dataset
-    (decennial/"long-form").}
+  \item{dataset}{either "acs" (the default), "acs_dp", "sf1", or "sf3",
+    indicating whether to look for tables and variables in the American
+    Community Survey, the Data Profile tables of the ACS, the SF1 dataset
+    (decennial/"short-form"), or the SF3 dataset (decennial/"long-form").}
 
     \item{keyword}{ a string or vector of strings giving the search
       term(s) to find in the name of the ACS census variable (for

--- a/man/api.key.exists.Rd
+++ b/man/api.key.exists.Rd
@@ -1,0 +1,35 @@
+\name{api.key.exists}
+\alias{api.key.exists}
+%- Also NEED an '\alias' for EACH other topic documented here.
+
+\title{
+Determines whether a US Census API key has been installed with
+\code{api.key.install()}.
+}
+\description{
+The \code{acs.fetch} function requires an "API key" to use when 
+downloading data from the US Census API. Other packages that depend 
+on \code{acs.fetch()} can use this function to determine whether they 
+\code{acs.fetch()} can be called. This is especially useful for other 
+packaages to test integration with the acs package, and automatically 
+determine if the integration test should be skipped until the 
+user completes acs setup.
+}
+\usage{
+if( ! acs::api.key.exists() ) {
+	# Skip test...
+}
+}
+\value{
+Returns True if a key has been set. Does not test whether the key is valid.
+}
+\references{
+To request an API key, see \url{http://www.census.gov/developers/}
+}
+\author{
+Josiah Johnston \email{josiah.johnston@berkeley.edu}
+}
+
+\seealso{
+\code{\link{api.key.install}}
+}

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(acs)
+
+test_check("acs")

--- a/tests/testthat/test_data_retrieval.R
+++ b/tests/testthat/test_data_retrieval.R
@@ -1,0 +1,45 @@
+library(acs)
+context("Integration test for downloading tiny datasets.")
+
+# If empty keys ever stop working we could add a snippet to skip the tests if an api key hasn't been installed.
+# Could also skip the tests if no network is available.
+
+test_that("acs_dp download works", {
+     dat = acs.fetch(
+          endyear=2013, span = 5, key='', 
+          geography=geo.make(zip.code='94709'),
+          variable=c("DP02_0069"),
+          dataset="acs_dp")
+     expect_equal(estimate(dat)[1,1], 249)
+     expect_equal(standard.error(dat)[1,1], 52.27964, tolerance=1e-4)
+})
+
+test_that("acs download works", {
+     dat = acs.fetch(
+          endyear=2013, span = 5, key='', 
+          geography=geo.make(zip.code='94709'),
+          variable=c("B01003_001"),
+          dataset="acs")
+     expect_equal(estimate(dat)[1,1], 12360)
+     expect_equal(standard.error(dat)[1,1], 397.5684, tolerance=1e-4)
+})
+
+test_that("sf1 download works", {
+     dat = acs.fetch(
+          endyear=2000, key='', 
+          geography=geo.make(state='CA'),
+          variable=c("P028E002"),
+          dataset="sf1")
+     expect_equal(estimate(dat)[1,1], 37339)
+     expect_equal(standard.error(dat)[1,1], 0, tolerance=1e-4)
+})
+
+test_that("sf3 download works", {
+     dat = acs.fetch(
+          endyear=2000, key='', 
+          geography=geo.make(state='CA'),
+          variable=c("PCT022035"),
+          dataset="sf3")
+     expect_equal(estimate(dat)[1,1], 88723)
+     expect_equal(standard.error(dat)[1,1], 0, tolerance=1e-4)
+})

--- a/vignettes/R.Cache_demo.Rmd
+++ b/vignettes/R.Cache_demo.Rmd
@@ -1,0 +1,70 @@
+---
+title: "Caching acs data"
+author: "Josiah Johnston"
+date: "`r Sys.Date()`"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Local cache demo}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+Retrieving data from the census API can be slow, and many applications make repeated use of the same data. This vignette demonstrates use of the R.Cache package to speed up acs.fetch() by caching results of each unique function call on the file system.
+
+R.Cache documentation at <https://cran.r-project.org/web/packages/R.cache/R.cache.pdf>
+
+## Install packages as needed
+```{r}
+# install.packages("R.cache")
+```
+
+## Set up a cache location before you load the R.cache library or else it may prompt you to make a cache folder in your home directory.
+```{r}
+cache.dir = file.path(system.file(package="acs"), "extdata", "cache", "demo")
+dir.create(cache.dir, recursive=T, showWarnings=F)
+R.cache::setCacheRootPath(cache.dir)
+```
+
+## Make a copy of the acs.fetch function that does file-level caching
+```{r}
+library(acs)
+acs.fetch.and.cache = R.cache::addMemoization(acs.fetch)
+```
+
+## Time the first call to download data.. 
+A half-dozen columns for one zip code takes me less than 2 seconds, but a whole table takes more like 28.
+```{r}
+system.time(acs.fetch.and.cache(
+     endyear=2013, span = 5, key='',
+     geography=geo.make(zip.code='94709'),
+     # table.number="DP02",
+     variable=c('DP02_0015', 'DP02_0013', 'DP02_0014', 'DP02_0066P', 'DP02_0067P', 'DP02_0079', 'DP02_0080'),
+     dataset="acs_dp"))
+```
+
+## Time the second call.. almost immediate from local caching
+```{r}
+system.time(acs.fetch.and.cache(
+     endyear=2013, span = 5, key='',
+     geography=geo.make(zip.code='94709'),
+     # table.number="DP02",
+     variable=c('DP02_0015', 'DP02_0013', 'DP02_0014', 'DP02_0066P', 'DP02_0067P', 'DP02_0079', 'DP02_0080'),
+     dataset="acs_dp"))
+
+```
+
+## Clear out the cache directory from this demo.
+```{r}
+unlink(cache.dir, recursive=TRUE)
+```
+
+## Notes:
+This does not do field-level deduplication. The results of each function call are stored in files that are named based on the function arguments. If you ask for the exact same data with a slightly different function call, the data will be stored twice. 
+
+## Other R.Cache features
+R.Cache supports simple memoization to automatically create a wrapper (demonstrated above).
+R.Cache also lets you write your own wrapper functions, which can be useful for marking things as stale, flushing the cache, etc. Key API elements:
+* Generate a cache key from a list
+* Query the cache for existence
+* Load or save data via a cache key
+* Delete an individual cached item


### PR DESCRIPTION
Add support for Data Profile tables from the American Community Survey. The REST API format and the variable metadata is slightly different, which required a few tweaks. Not all margins of error are available for all variables, which meant a few other tweaks to avoid extrapolating non-existent variables. Data Profile tables are officially available for 2012 onwards, but only 2013 and 2014 are working for me at the moment.